### PR TITLE
Add Krastorio compatibility for water field

### DIFF
--- a/Scripts/Other/ModsCompatibility.lua
+++ b/Scripts/Other/ModsCompatibility.lua
@@ -1,3 +1,7 @@
 if mods["RITEG"] and mods["metal-and-stars"] then
     data.raw["tool"]["nanite-science-pack"].auto_enrich = false
 end
+
+if mods["Krastorio2"] or mods["Krastorio2-spaced-out"] then
+    table.insert(data.raw["mining-drill"]["kr-mineral-water-pumpjack"].resource_categories, "igrys-water")
+end

--- a/info.json
+++ b/info.json
@@ -4,7 +4,14 @@
   "title": "Igrys",
   "author": "EgorexW",
   "factorio_version": "2.0",
-  "dependencies": ["base >= 2.0", "space-age >= 1.0", "PlanetsLib >= 1.2", "new-diagonal-inserter >= 1.0.5", "? RITEG >= 1.3.11", "? metal-and-stars >= 0.1.13"],
+  "dependencies": [
+    "base >= 2.0",
+    "space-age >= 1.0",
+    "PlanetsLib >= 1.2",
+    "new-diagonal-inserter >= 1.0.5",
+    "? RITEG >= 1.3.11",
+    "? metal-and-stars >= 0.1.13",
+    "? Krastorio2-spaced-out >= 1.4.0"],
   "description": "Igrys – A new planet with magic-powered science, advanced glassworking, and alternative production chains",
   "space_travel_required": true
 }


### PR DESCRIPTION
Water field is not mineable when playing with krastorio. This allows to mine water field with mineral water pumpjack.