### PR TITLE
Add Metallurgic science as a prerequisite to glassworking 3

### DIFF
--- a/Scripts/Other/Technologies.lua
+++ b/Scripts/Other/Technologies.lua
@@ -220,6 +220,7 @@ data:extend({
             }
         },
         prerequisites = {
+            "metallurgic-science-pack",
             "igrys-glassworking-2",
         },
         unit = {


### PR DESCRIPTION
Add Metallurgic science as a prerequisite to glassworking 3, as it already requires metallurgic packs to research. This won't effect gameplay, just makes the tech tree look nicer, especially if using a mod like Discovery Tree. 