### PR TITLE
Canal Excavator compatibility

### DIFF
--- a/compatibility/canal-excavator.lua
+++ b/compatibility/canal-excavator.lua
@@ -1,0 +1,18 @@
+if not mods["canal-excavator"] then return end
+
+data:extend({{
+  type = "mod-data",
+  name = "canex-igrys-config",
+  data_type = "canex-surface-config",
+  data = {
+    surfaceName = "igrys",
+    localisation = {"space-location-name.igrys"},
+    mineResult = "stone",
+    oreStartingAmount = 25,
+    mining_time = data.raw["resource"]["igrys-stone"].minable.mining_time,
+    tint = {r = 125, g = 20, b = 230},
+    icon_data = {
+      icon_size = 500,
+    }
+  },
+}})

--- a/compatibility/data.lua
+++ b/compatibility/data.lua
@@ -1,0 +1,1 @@
+require("compatibility.canal-excavator")

--- a/data.lua
+++ b/data.lua
@@ -33,3 +33,5 @@ require("Scripts.Other.Technologies")
 require("Scripts.Other.Groups")
 require("Scripts.Other.SpidertronSteal")
 require("Scripts.Other.BaseIntegration")
+
+require("compatibility.data")

--- a/info.json
+++ b/info.json
@@ -8,7 +8,8 @@
     "base >= 2.0",
     "space-age >= 1.0",
     "PlanetsLib >= 1.2",
-    "? new-diagonal-inserter >= 1.0.5"],
+    "? new-diagonal-inserter >= 1.0.5",
+    "? canal-excavator >= 1.11"],
   "description": "Igrys – A new planet with magic-powered science, advanced glassworking, and alternative production chains",
   "space_travel_required": true
 }


### PR DESCRIPTION
Hi,

Some users of my [Canal Excavator](https://mods.factorio.com/mod/canal-excavator) mod asked me to implement compatibility with more planet mods.
Personally I think it's cleaner if the compatibility code is in the planet mod so let me know if you're okay with adding this.

Since, as far as I could find, you didn't have any other compatibility code in your project yet, I've added a basic structure I've seen and used in other projects. Furthermore, if you want you could change the dependency to hidden `(?)`, but I leave that up to you.

The excavatable resource on Igrys yields stone and I've set the mining time to be equal to that of your Hard Stone resource but if you want it to be harder for players to create canals you could increase it or `oreStartingAmount` to something higher. I've also tried to match the resource's color tint to match your stone.

Let me know what you think.